### PR TITLE
Возможность задавать Разрядность.

### DIFF
--- a/src/GyverNTC.h
+++ b/src/GyverNTC.h
@@ -24,8 +24,8 @@
 
 class GyverNTC {
 public:
-    GyverNTC(uint8_t pin, uint32_t resistance, uint16_t beta, uint8_t tempBase = 25, uint32_t base = 10000) :
-    _pin(pin), _beta(beta), _tempBase(tempBase), _baseDivRes((float)base / resistance) {}
+    GyverNTC(uint8_t pin, uint32_t resistance, uint16_t beta, uint8_t tempBase = 25, uint32_t base = 10000, uint8_t adcBit = 10) :
+    _pin(pin), _beta(beta), _tempBase(tempBase), _baseDivRes((float)base / resistance, _adcBit(adcBit)) {}
     
     // прочитать температуру с пина
     float getTemp() {
@@ -39,9 +39,9 @@ public:
         return computeTemp((float)aver / _T_SAMPLE_AVERAGE);
     }
     
-    // получить температуру из сигнала АЦП (10 бит, float)
+    // получить температуру из сигнала АЦП (10 бит по умолчанию, float)
     float computeTemp(float analog) {
-        analog = _baseDivRes / (1023.0f / analog - 1.0);
+        analog = _baseDivRes / (float((1 << _adcBit) - 1) / analog - 1.0);
         analog = (log(analog) / _beta) + 1.0 / (_tempBase + 273.15);
         return (1.0 / analog - 273.15);
     }
@@ -51,5 +51,6 @@ private:
     const uint16_t _beta = 0;
     const uint8_t _tempBase = 25;
     const float _baseDivRes;
+    const uint8_t _adcBit = 10;
 };
 #endif


### PR DESCRIPTION
Параметр разрядности АЦП при инициализации, для использования модуля с различными платами. Там есть analogReadResolution() для установки количества бит, но нету возможности узнать, что было установлено. Каждые библиотеки по своему интерпретируют этот сеттер, и фактически надо знать их архитектуру, что бы просто узнать, что там было установление. Поэтому, предлагаю, что проще указать, чем пытаться выяснить, что там за разрядность указана.